### PR TITLE
Makefile: pass bin-annot to support jump to location in Merlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 _build/
 *.native
 *.byte
-test.js

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ all: native
 
 native:
 	$(OCAMLC) \
+		-cflags -bin-annot \
 		-Is $(INCLUDE) \
 		-use-ocamlfind \
 		-pkgs $(PKGS) \
@@ -16,6 +17,7 @@ native:
 
 byte:
 	$(OCAMLC) \
+		-cflags -bin-annot \
 		-Is $(INCLUDE) \
 		-use-ocamlfind \
 		-pkgs $(PKGS) \
@@ -30,3 +32,6 @@ js: byte
 		--disable share \
 		--enable excwrap \
 		$(JS_MAIN)
+		
+clean:
+	rm -rf _build *.native *.byte

--- a/src/cmd.re
+++ b/src/cmd.re
@@ -7,7 +7,7 @@ let speclist = [("-debug", Arg.Set debug, "Enables debugging mode")];
 let load_file fname => {
   let ic = open_in fname;
   let n = in_channel_length ic;
-  let s = String.create n;
+  let s = Bytes.create n;
   really_input ic s 0 n;
   close_in ic;
   Bytes.to_string s


### PR DESCRIPTION
Also add clean, and remove deprecated warning on String.create.