### PR TITLE
Promise Support

### DIFF
--- a/src/__tests__/__snapshots__/compile.js.snap
+++ b/src/__tests__/__snapshots__/compile.js.snap
@@ -67,6 +67,21 @@ exports[`Compile optional-param.re 1`] = `
 "
 `;
 
+exports[`Compile promise.re 1`] = `
+"external pOfString : unit => Js_promise.t string = \\"\\" [@@bs.module \\"promise\\"];
+
+external pOfNumber : unit => Js_promise.t float = \\"\\" [@@bs.module \\"promise\\"];
+
+external pOfArray : unit => Js_promise.t (array string) = \\"\\" [@@bs.module \\"promise\\"];
+
+external pOfVoid : unit => Js_promise.t unit = \\"\\" [@@bs.module \\"promise\\"];
+
+external argPromise : p::Js_promise.t string => unit = \\"\\" [@@bs.module \\"promise\\"];
+
+external somePromise : Js_promise.t (array float) = \\"\\" [@@bs.module \\"promise\\"];
+"
+`;
+
 exports[`Compile simple.re 1`] = `
 "external add : x::float => y::float => float = \\"\\" [@@bs.module \\"simple\\"];
 "
@@ -77,6 +92,29 @@ exports[`Compile simple-class.re 1`] = `
 
 external create_test : t::string => test =
   \\"Test\\" [@@bs.new] [@@bs.module \\"simple-class\\"];
+"
+`;
+
+exports[`Compile spread-args.re 1`] = `
+"external foo : bars::array float => unit = \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external optFoo : bars::array float => unit =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external bothFoo : anArg::string => bars::array float => unit =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external bothOptFoo : anArg::string => bars::array float => unit =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external soManyOpts : anArg::string? => unit => bars::array float => unit =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external returns : anArg::string => bars::array float => float =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+
+external multipleLists : foos::array float => bars::array float => unit =
+  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
 "
 `;
 
@@ -99,5 +137,10 @@ external number_or_string : union_of_number_or_string => number_or_string =
   \\"Array.prototype.shift.call\\" [@@bs.val];
 
 external double : x::number_or_string => float = \\"\\" [@@bs.module \\"union-type\\"];
+"
+`;
+
+exports[`Compile void-func.re 1`] = `
+"external voidFunc : unit => unit = \\"\\" [@@bs.module \\"void-func\\"];
 "
 `;

--- a/src/__tests__/fixtures/promise.js
+++ b/src/__tests__/fixtures/promise.js
@@ -1,0 +1,7 @@
+declare module 'promise' {
+  declare export function pOfString(): Promise<string>
+  declare export function pOfNumber(): Promise<number>
+  declare export function pOfArray(): Promise<string[]>
+  declare export function pOfVoid(): Promise<void>
+  declare export function argPromise(p: Promise<string>): void
+}

--- a/src/__tests__/fixtures/promise.js
+++ b/src/__tests__/fixtures/promise.js
@@ -4,5 +4,6 @@ declare module 'promise' {
   declare export function pOfArray(): Promise<string[]>
   declare export function pOfVoid(): Promise<void>
   declare export function argPromise(p: Promise<string>): void
+  declare export function listOfPromises(): Promise<string>[]
   declare export var somePromise: Promise<number[]>
 }

--- a/src/__tests__/fixtures/promise.js
+++ b/src/__tests__/fixtures/promise.js
@@ -4,4 +4,5 @@ declare module 'promise' {
   declare export function pOfArray(): Promise<string[]>
   declare export function pOfVoid(): Promise<void>
   declare export function argPromise(p: Promise<string>): void
+  declare export var somePromise: Promise<number[]>
 }

--- a/src/__tests__/fixtures/promise.re
+++ b/src/__tests__/fixtures/promise.re
@@ -1,0 +1,5 @@
+external pOfString : unit => Js_promise.t string = "" [@@bs.module "promise"];
+external pOfNumber : unit => Js_promise.t float = "" [@@bs.module "promise"];
+external pOfArray : unit => Js_promise.t array string = "" [@@bs.module "promise"];
+external pOfVoid : unit => Js_promise.t unit = "" [@@bs.module "promise"];
+external argPromise : p::Js_promise.t string => unit = "" [@@bs.module "promise"];

--- a/src/__tests__/fixtures/promise.re
+++ b/src/__tests__/fixtures/promise.re
@@ -1,5 +1,6 @@
 external pOfString : unit => Js_promise.t string = "" [@@bs.module "promise"];
 external pOfNumber : unit => Js_promise.t float = "" [@@bs.module "promise"];
-external pOfArray : unit => Js_promise.t array string = "" [@@bs.module "promise"];
+external pOfArray : unit => Js_promise.t (array string) = "" [@@bs.module "promise"];
 external pOfVoid : unit => Js_promise.t unit = "" [@@bs.module "promise"];
 external argPromise : p::Js_promise.t string => unit = "" [@@bs.module "promise"];
+external somePromise : Js_promise.t (array float) = "" [@@bs.module "promise"];

--- a/src/__tests__/fixtures/promise.re
+++ b/src/__tests__/fixtures/promise.re
@@ -3,4 +3,5 @@ external pOfNumber : unit => Js_promise.t float = "" [@@bs.module "promise"];
 external pOfArray : unit => Js_promise.t (array string) = "" [@@bs.module "promise"];
 external pOfVoid : unit => Js_promise.t unit = "" [@@bs.module "promise"];
 external argPromise : p::Js_promise.t string => unit = "" [@@bs.module "promise"];
+external listOfPromises: unit => array (Js_promise.t string) = "" [@@bs.module "promise"];
 external somePromise : Js_promise.t (array float) = "" [@@bs.module "promise"];

--- a/src/retyped/codegen.re
+++ b/src/retyped/codegen.re
@@ -85,7 +85,7 @@ let rec bstype_to_code ::ctx=intctx =>
     (Genutils.is_type_param ctx.type_params s ? "'" : "") ^ String.uncapitalize_ascii s |> Genutils.normalize_name
   | Union types => union_types_to_name types
   | Typeof t => raise (CodegenTypeError "Typeof can only operate on variable declarations")
-  | Promise t => "Js_promise.t " ^ bstype_to_code t
+  | Promise t => "Js_promise.t (" ^ bstype_to_code ::ctx t ^ ")"
   | StringLiteral _ =>
     raise (CodegenTypeError "Cannot use string literal outside the context of a union type")
   | Function type_params params rest_param rt => {

--- a/src/retyped/codegen.re
+++ b/src/retyped/codegen.re
@@ -66,7 +66,7 @@ let rec bstype_to_code ::ctx=intctx =>
   | Optional t => bstype_to_code ::ctx t
   | Unit => "unit"
   | Null => "null"
-  | Array t => "array " ^ bstype_to_code ::ctx t
+  | Array t => "array (" ^ bstype_to_code ::ctx t ^ ")"
   | Tuple types => Render.tupleType types::(List.map (bstype_to_code ::ctx) types) ()
   | Any => "'any"
   | AnyObject => "'any"

--- a/src/retyped/flowprinter.re
+++ b/src/retyped/flowprinter.re
@@ -65,6 +65,7 @@ let rec show_type =
       "{ " ^
       String.concat "; " (List.map (fun (key, prop) => key ^ ": " ^ show_type prop) props) ^ " }"
     | BsType.Named s => s
+    | BsType.Promise t => "Promise<" ^ show_type t ^ ">"
     | BsType.StringLiteral t => "\"" ^ t ^ "\""
   );
 


### PR DESCRIPTION
From #12. This seemed suspiciously straightforward, so I hope I understood the ask correctly! This parses `Promise` as a single-param `BsType.t`, with associated codegen.

Also, I added parenthesization (sp?) to array-type code gen so you can get, e.g. `array (Js_promise.t string)`.

PS 101 tests now passing! Arbitrary base-10 counting system success landmarks FTW!