### PR TITLE
Js Date

### DIFF
--- a/src/retyped/codegen.re
+++ b/src/retyped/codegen.re
@@ -31,6 +31,7 @@ let rec bstype_name =
     raise (CodegenTypeError "Unable to translate class into type name")
   | Optional t => bstype_name t
   | Promise t => "promise_" ^ bstype_name t
+  | Date => "date"
   | StringLiteral _ =>
     raise (
       CodegenTypeError "Cannot use string literal outside the context of a union type"
@@ -169,7 +170,8 @@ let rec bstype_to_code ::ctx=intctx =>
           )
           props;
       Render.classType types::class_types ()
-    };
+    }
+    | Date => "Js.Date.t";
 
 module Precode = {
   let rec bstype_precode def =>

--- a/src/retyped/flowprinter.re
+++ b/src/retyped/flowprinter.re
@@ -81,6 +81,7 @@ let rec show_type =
       )
     | BsType.Promise t => "Promise<" ^ show_type t ^ ">"
     | BsType.StringLiteral t => "\"" ^ t ^ "\""
+    | BsType.Date => "Date"
   );
 
 let rec show_decl =

--- a/src/retyped/modulegen.re
+++ b/src/retyped/modulegen.re
@@ -80,7 +80,8 @@ module BsType = {
     | Named (list t) string
     | Optional t
     | StringLiteral string
-    | Promise t;
+    | Promise t
+    | Date;
 };
 
 let string_of_id (loc: Loc.t, id: string) => id;
@@ -287,6 +288,7 @@ and generic_type_to_bstype ctx g => {
 }
 and named_to_bstype ctx type_params (loc, id) =>
   switch id {
+  | "Date" => BsType.Date
   | "RegExp" => BsType.Regex
   | "Object" => BsType.AnyObject
   | "Array" =>


### PR DESCRIPTION
Added support for javascript dates

flow's `Date` gets transformed to bucklescript's `Js.Date.t`

### PR Checklist
- [x] Corresponding issue: #31
- [x] Formatted code with `refmt`
- [ ] Ran tests `npm test` and updated snapshots
