### PR TITLE
[RFC] Add support for optional flow types

### DIFF
--- a/lib/__tests__/fixtures/maybe.js
+++ b/lib/__tests__/fixtures/maybe.js
@@ -1,0 +1,5 @@
+type maybeTypes = {
+  a: ?string,
+  b?: string,
+  c?: ?string
+}

--- a/lib/__tests__/fixtures/maybe.re
+++ b/lib/__tests__/fixtures/maybe.re
@@ -1,0 +1,1 @@
+type maybeTypes = Js.t {.. a : Js.null_undefined string, b : Js.undefined string, c : Js.null_undefined string };

--- a/src/retyped/codegen.re
+++ b/src/retyped/codegen.re
@@ -81,7 +81,7 @@ let rec bstype_to_code ::ctx=intctx =>
   fun
   | Regex => "Js.Re.t"
   | Dict t => "Js.Dict.t (" ^ bstype_to_code ::ctx t ^ ")"
-  | Optional t => bstype_to_code ::ctx t
+  | Optional t => "Js.null_undefined (" ^ bstype_to_code ::ctx t ^ ")"
   | Unit => "unit"
   | Null => "null"
   | Array t => "array (" ^ bstype_to_code ::ctx t ^ ")"

--- a/src/retyped/optimizer.re
+++ b/src/retyped/optimizer.re
@@ -38,7 +38,7 @@ let optimize_statements types statements =>
     )
     statements;
 
-let optimize types::(types: list (string, Retyped.Typetable.t)) program =>
+let optimize types::(types: list (string, Typetable.t)) program =>
   switch program {
   | ModuleDecl id statements =>
     ModuleDecl id (optimize_statements types statements)


### PR DESCRIPTION
Adds support for optional types. Only supports optional values, not optional params.

With this diff
```
type maybeTypes = {
  a: ?string,
  b?: string,
  c?: ?string
}
```
will generate 
```
type maybeTypes = Js.t {.. a : Js.null_undefined string, b : string, c : Js.null_undefined string };
```
but I think it should generate b as `Js.undefined string`. 

It breaks external function declarations. I could use a pointer to how I can distinguish between a type and an external declaration.

Example:

```
declare function someFunction(a?: string): string
```
before this diff, would generate something like
```
external someFunction : a::string? => string
```
now it generates something like:
```
external someFunction : a::Js.null_undefined string? => string
```

### PR Checklist
- [ ] Corresponding issue: #0000 
- [X] Formatted code with `refmt`
- [X] Ran tests `npm test` and updated snapshots
