### PR TITLE
Modify position of `bs.string` attribute

### DIFF
--- a/lib/__tests__/__snapshots__/compile.js.snap
+++ b/lib/__tests__/__snapshots__/compile.js.snap
@@ -98,6 +98,11 @@ external apply : (~x: float, ~y: float, ~options: options=?, unit) => float = \\
 "
 `;
 
+exports[`Compile literal-type.re 1`] = `
+"[@bs.module \\"literal-type\\"] external f : (~x: [@bs.string] [ | \`a | \`b]) => unit = \\"\\";
+"
+`;
+
 exports[`Compile multiple-modules.re 1`] = `
 "[@bs.module \\"multiple-modules\\"] external someTopLevel : unit => unit = \\"\\";
 

--- a/lib/__tests__/fixtures/literal-type.js
+++ b/lib/__tests__/fixtures/literal-type.js
@@ -1,0 +1,3 @@
+declare module 'literal-type' {
+  declare export function f(x: "a" | "b"): void;
+}

--- a/lib/__tests__/fixtures/literal-type.re
+++ b/lib/__tests__/fixtures/literal-type.re
@@ -1,0 +1,1 @@
+[@bs.module "literal-type"] external f : (~x:([@bs.string][`a | `b])) => unit = "";

--- a/src/render.re
+++ b/src/render.re
@@ -139,9 +139,12 @@ let functionType =
 let tupleType = (~types, ()) => "(" ++ String.concat(", ", types) ++ ")";
 
 let unionTypeStrings = (~types, ()) =>
-  "(["
-  ++ (List.map(type_name => "`" ++ type_name, types) |> String.concat(" | "))
-  ++ "] [@bs.string])";
+  Printf.(
+    sprintf(
+      "([@bs.string] [%s])",
+      types |> List.map(sprintf("`%s")) |> String.concat(" | ")
+    )
+  );
 
 let unionType = (~name, ~types, ()) =>
   "type union_of_"


### PR DESCRIPTION
<!-- Please provide a brief description of the changes -->

Modified position of `bs.string` attribute from a tail of definition to head of it

<!-- If possible, provide sample input and output -->

### Sample input

```
declare module 'literal-type' {
  declare export function f(x: "a" | "b"): void;
}
```

### Sample output(before)

```
[@bs.module "literal-type"] external f : (~x:([`a | `b] [@bs.string])) => unit = "";
```

### Sample output(after)

```
[@bs.module "literal-type"] external f : (~x:([@bs.string] [`a | `b])) => unit = "";
```

### PR Checklist
- [x] Corresponding issue: #50  
- [x] Formatted code with `refmt`
- [x] Ran tests `npm test` and updated snapshots
