### PR TITLE
Fix bs.module annotations and make simple ts test

### DIFF
--- a/lib/__tests__/__snapshots__/compile.js.snap
+++ b/lib/__tests__/__snapshots__/compile.js.snap
@@ -174,6 +174,11 @@ exports[`Compile simple.re 1`] = `
 "
 `;
 
+exports[`Compile simple.re 2`] = `
+"[@bs.module \\"simple\\"] external add : (~x: float, ~y: float) => float = \\"\\";
+"
+`;
+
 exports[`Compile simple-class.re 1`] = `
 "module Test = {
   type t = {. \\"action\\": 't 's .[@bs.meth] (float => string)};

--- a/lib/__tests__/fixtures/simple.d.ts
+++ b/lib/__tests__/fixtures/simple.d.ts
@@ -1,0 +1,1 @@
+declare function add(x: number, y: number): number

--- a/src/compiler.re
+++ b/src/compiler.re
@@ -6,8 +6,15 @@ module Stage = {
       let (_, statements, _) = flowAst;
       statements;
     };
-    let parseTypescriptSource = (name, source) =>
-      Typescript.parse(name, source);
+    let parseTypescriptSource = (filename, source) => {
+      let last5 = String.sub(filename, String.length(filename) - 5, 5);
+      let module_name =
+        switch last5 {
+        | ".d.ts" => String.sub(filename, 0, String.length(filename) - 5)
+        | _ => String.sub(filename, 0, String.length(filename) - 3)
+        };
+      Typescript.parse(module_name, source);
+    };
     let extension = String.sub(name, String.length(name) - 3, 3);
     switch extension {
     | ".js" =>


### PR DESCRIPTION
Fixes #53.

Removes the file extension from module name in the `@bs.module` annotation when run on a typescript file.
Adds an integration test for this problem.

### PR Checklist
- [x] Corresponding issue: #53
- [x] Formatted code with `refmt`
- [x] Ran tests `npm test` and updated snapshots