### PR TITLE
Remove link to nonexistent DEVELOPING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Compiles a libdef, formats the result, and handles errors cleanly
 
 ## Development
 
-See [DEVELOPING](DEVELOPING.md) and [CONTRIBUTING](CONTRIBUTING.md).
+See [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Status
 


### PR DESCRIPTION
Just a quick edit to remove this broken link. This file must have been removed at some point.