### PR TITLE
Better error output for parse errors

### DIFF
--- a/bindings/typescript.re
+++ b/bindings/typescript.re
@@ -618,6 +618,7 @@ type parseDiagnostic = {
   start: int,
   messageText: string,
   category: int,
+  length: int,
   code: int
 };
 
@@ -727,7 +728,8 @@ module Decoder = {
       start: json |> field("start", int),
       messageText: json |> field("messageText", string),
       category: json |> field("category", int),
-      code: json |> field("code", int)
+      code: json |> field("code", int),
+      length: json |> field("length", int)
     };
   external nodeToJson : Internal.node => Js.Json.t = "%identity";
   let rec decoders = [

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,17 +55,32 @@ function compileFile(filePath) {
       const fileSource = data.toString()
       let moduleName
       let bsCode
+      let diagnosticErrors 
 
       try {
         const result = ReasonablyTyped.compile(
           fileSource,
           fileName,
-          false,
+          true,
           debugMode,
         )
 
-        moduleName = result[0]
-        bsCode = result[1]
+        moduleName = result.moduleName
+        bsCode = result.bsCode
+        diagnosticErrors = result.diagnosticErrors
+        if (diagnosticErrors.length > 0) {
+          console.log(`${chalk.red('✘')} Parse error "${filePath}"`)
+          diagnosticErrors.forEach(e => {
+            console.log()
+            console.log(
+              codeFrame(e.source, e.line, e.column, {
+                highlightCode: true,
+              }),
+            )
+            console.log()
+          });
+          return resolve(false)
+        }
       } catch (e) {
         const fileLocation = e.message.match(/\[in.*from (\d+):(\d+).*\]/)
         if (!fileLocation) return reject(e)

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,16 +45,16 @@ function compile(
   let resName
 
   try {
-    const [moduleName, bsCode] = Retyped.compile(filename, source, debugMode)
+    const [moduleName, bsCode, diagnosticError] = Retyped.compile(filename, source, debugMode)
     const fmtCode = format(bsCode)
     res = fmtCode
     resName = moduleName
-  } catch (e) {
-    if (e[0][0] === "Diagnostic.Error") {
+    if (diagnosticError.length > 0) {
       console.log('\x1b[31m%s\n\x1b[0m', '[PARSE ERROR]');
-      console.log(e[1])
+      console.log(diagnosticError)
       process.exit(1)
     }
+  } catch (e) {
     console.error(e)
     throw new Error(`${e[0][0]}`)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const reason = require('reason')
+const codeFrame = require('babel-code-frame')
 const Retyped = require('./js/src/compiler')
 
 /**
@@ -45,13 +46,21 @@ function compile(
   let resName
 
   try {
-    const [moduleName, bsCode, diagnosticError] = Retyped.compile(filename, source, debugMode)
+    const [moduleName, bsCode, diagnosticErrors] = Retyped.compile(filename, source, debugMode)
     const fmtCode = format(bsCode)
     res = fmtCode
     resName = moduleName
-    if (diagnosticError.length > 0) {
+    if (diagnosticErrors.length > 0) {
       console.log('\x1b[31m%s\n\x1b[0m', '[PARSE ERROR]');
-      console.log(diagnosticError)
+      diagnosticErrors.forEach(e => {
+        console.log()
+        console.log(
+          codeFrame(e.source, e.line, e.column, {
+            highlightCode: true,
+          }),
+        )
+        console.log()
+      });
       process.exit(1)
     }
   } catch (e) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,9 @@ function compile(
     res = fmtCode
     resName = moduleName
   } catch (e) {
-    if (e[0][0] === "Diagnostic.DiagnosticError") {
-      console.error(e[1])
+    if (e[0][0] === "Diagnostic.Error") {
+      console.log('\x1b[31m%s\n\x1b[0m', '[PARSE ERROR]');
+      console.log(e[1])
       process.exit(1)
     }
     console.error(e)

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ function compile(
     res = fmtCode
     resName = moduleName
   } catch (e) {
-    if (e[0][0] === "Compiler.ReportableError") {
+    if (e[0][0] === "Diagnostic.DiagnosticError") {
       console.error(e[1])
       process.exit(1)
     }
@@ -69,4 +69,7 @@ function compile(
   }
 }
 
-module.exports = {format, compile}
+module.exports = {
+  format,
+  compile
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,10 @@ function compile(
     res = fmtCode
     resName = moduleName
   } catch (e) {
+    if (e[0][0] === "Compiler.ReportableError") {
+      console.error(e[1])
+      process.exit(1)
+    }
     console.error(e)
     throw new Error(`${e[0][0]}`)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const reason = require('reason')
-const codeFrame = require('babel-code-frame')
 const Retyped = require('./js/src/compiler')
 
 /**
@@ -44,25 +43,14 @@ function compile(
 ) {
   let res
   let resName
+  let errors
 
   try {
     const [moduleName, bsCode, diagnosticErrors] = Retyped.compile(filename, source, debugMode)
     const fmtCode = format(bsCode)
     res = fmtCode
     resName = moduleName
-    if (diagnosticErrors.length > 0) {
-      console.log('\x1b[31m%s\n\x1b[0m', '[PARSE ERROR]');
-      diagnosticErrors.forEach(e => {
-        console.log()
-        console.log(
-          codeFrame(e.source, e.line, e.column, {
-            highlightCode: true,
-          }),
-        )
-        console.log()
-      });
-      process.exit(1)
-    }
+    errors = diagnosticErrors
   } catch (e) {
     console.error(e)
     throw new Error(`${e[0][0]}`)
@@ -75,7 +63,11 @@ function compile(
   if (!includeModule) {
     return res
   } else {
-    return [resName, res]
+    return {
+      moduleName: resName,
+      bsCode: res,
+      diagnosticErrors: errors
+    }
   }
 }
 

--- a/src/compiler.re
+++ b/src/compiler.re
@@ -21,18 +21,19 @@ module Stage = {
       let parts = Js.String.split(".", name);
       parts[Array.length(parts) - 1];
     };
-    switch extension {
+    switch (extension) {
     | "js" =>
-      parseFlowSource(name, source) |> List.map(FlowBsType.flowAstToBsTypeAst)
+      parseFlowSource(name, source)
+      |> List.map(FlowBsType.flowAstToBsTypeAst)
     | "ts" => [
         parseTypescriptSource(name, source)
-        |> TypescriptBsType.typescriptAstToBsTypeAst
+        |> TypescriptBsType.typescriptAstToBsTypeAst,
       ]
     | "graphql" => [
-        Graphql.parse(name, source) |> GraphqlBsType.graphqlAstToBsTypeAst
+        Graphql.parse(name, source) |> GraphqlBsType.graphqlAstToBsTypeAst,
       ]
     | "css" => [
-        Csstree.parse(name, source) |> CssBsType.cssAstToBsTypeAst(name)
+        Csstree.parse(name, source) |> CssBsType.cssAstToBsTypeAst(name),
       ]
     | _ => []
     };
@@ -49,26 +50,26 @@ module Stage = {
       program =>
         BsTypeReason.program_to_code(
           program,
-          make_module_typetable(program) @ globalTypeTable
+          make_module_typetable(program) @ globalTypeTable,
         ),
-      programs
+      programs,
     );
   };
   let combineAst =
     List.fold_left(
       ((current_id, all_code), result) =>
-        switch result {
+        switch (result) {
         | Some((program_id, program_code)) when program_id !== "" => (
             program_id,
-            all_code ++ "\n" ++ program_code
+            all_code ++ "\n" ++ program_code,
           )
         | Some((_program_id, program_code)) => (
             current_id,
-            all_code ++ "\n" ++ program_code
+            all_code ++ "\n" ++ program_code,
           )
         | None => (current_id, all_code)
         },
-      ("Unknown ID", "")
+      ("Unknown ID", ""),
     );
   module Debug = {
     open BsTypeAst;
@@ -89,7 +90,7 @@ module Stage = {
         | ModuleDecl(_name, _statements) as md =>
           Typetable.show(make_module_typetable(md))
         | _ => (),
-        programs
+        programs,
       );
     };
     let showFlow = programs => {
@@ -100,7 +101,7 @@ module Stage = {
       print_newline();
     };
     let showCode = result => {
-      let (name, code) = result;
+      let (name, code, _) = result;
       print_endline("\027[1;36m=== Bucklescript Definition ===\027[0m");
       print_endline("\027[1;30m/* Module " ++ name ++ " */\027[0m");
       print_endline(code);
@@ -118,9 +119,18 @@ let compile = (moduleName, moduleSource, debug) => {
       |> List.map(Stage.optimizeAst)
       |> Stage.renderAst
       |> Stage.combineAst
+      |> (((id, code)) => (id, code, ""))
     ) {
-    | Parse_error.Error(xs) =>
-      raise(Diagnostic.diagnosticOfFlow(xs, moduleSource))
+    | Parse_error.Error(xs) => (
+        "Unknown ID",
+        "",
+        Diagnostic.diagnosticOfFlow(xs, moduleSource),
+      )
+    | Diagnostic.Error(x) => (
+        "Unknown ID",
+        "",
+        x
+      )
     };
   if (debug) {
     let debugAsts = Stage.parseSource(moduleName, moduleSource);

--- a/src/compiler.re
+++ b/src/compiler.re
@@ -120,21 +120,7 @@ let compile = (moduleName, moduleSource, debug) => {
       |> Stage.combineAst
     ) {
     | Parse_error.Error(xs) =>
-      raise(ReportableError(
-        xs
-        |> List.map(
-          ((loc, ty)) => {
-            let { Loc.line, column } = Loc.(loc.start);
-            let offset = Belt.List.make(column, " ") |> String.concat("");
-            moduleSource
-              |> Js.String.split("\n")
-              |> Belt.List.ofArray
-              |> Belt.List.getExn(_, (line - 1))
-              |> (s => Printf.sprintf("%s\n%s^ %s", s, offset, Parse_error.PP.error(ty)))
-          }
-        )
-        |> String.concat("\n")
-      ));
+      raise(Diagnostic.diagnosticOfFlow(xs, moduleSource))
     };
   if (debug) {
     let debugAsts = Stage.parseSource(moduleName, moduleSource);

--- a/src/compiler.re
+++ b/src/compiler.re
@@ -119,17 +119,17 @@ let compile = (moduleName, moduleSource, debug) => {
       |> List.map(Stage.optimizeAst)
       |> Stage.renderAst
       |> Stage.combineAst
-      |> (((id, code)) => (id, code, ""))
+      |> (((id, code)) => (id, code, [||]))
     ) {
     | Parse_error.Error(xs) => (
         "Unknown ID",
         "",
         Diagnostic.diagnosticOfFlow(xs, moduleSource),
       )
-    | Diagnostic.Error(x) => (
+    | Diagnostic.Error(xs) => (
         "Unknown ID",
         "",
-        x
+        xs
       )
     };
   if (debug) {

--- a/src/diagnostic.re
+++ b/src/diagnostic.re
@@ -1,4 +1,4 @@
-exception DiagnosticError(string);
+exception Error(string);
 
 type diagnostic = {
   source: string,
@@ -8,57 +8,64 @@ type diagnostic = {
 };
 
 let pp = ({line, column, reason, source}) => {
+  let lineNumberOfIndex = fun
+  | i when(i < 10) => Printf.sprintf("  %d", i)
+  | i when(i < 100) => Printf.sprintf(" %d", i)
+  | i => Printf.sprintf("%d", i)
+  ;
+
   let offset = Belt.List.make(column, " ") |> String.concat("");
   source
-    |> Js.String.split("\n")
-    |> Belt.List.ofArray
-    |> Belt.List.getExn(_, (line - 1))
-    |> (s => Printf.sprintf("%s\n%s^ %s", s, offset, reason))
+  |> Js.String.split("\n")
+  |> Belt.List.ofArray
+  |> Belt.List.mapWithIndex(_, (i, code) => Printf.sprintf("%s | %s", lineNumberOfIndex(i), code))
+  |> (
+    codes =>
+      switch (Belt.List.splitAt(codes, line)) {
+      | Some((xs, ys)) =>
+        Belt.List.concat(
+          xs,
+          Belt.List.add(ys, Printf.sprintf("\027[31m      %s^ %s\027[0m", offset, reason))
+        )
+      | None => []
+      }
+  )
+  |> String.concat("\n");
 };
 
-let diagnosticOfFlow = (errors, source) => {
+let diagnosticOfFlow = (errors, source) =>
   errors
-    |> List.map(
-      ((loc, ty)) => {
-      let { Loc.line, column } = Loc.(loc.start);
-      pp({
-        line,
-        column,
-        source,
-        reason: Parse_error.PP.error(ty),
-      })
-    })
-    |> String.concat("\n")
-  |> x => DiagnosticError(x)
-};
+  |> List.map(((loc, ty)) => {
+       let {Loc.line, column} = Loc.(loc.start);
+       pp({line, column, source, reason: Parse_error.PP.error(ty)});
+     })
+  |> String.concat("\n----------------\n")
+  |> (x => Error(x));
 
-let rec computeColumnAndLine = (~column = 1, ~line = 1, source) => fun
-| 0 => (column, line)
-| pos => {
-  let head = Js.String.get(source, 0);
-  let tail = Js.String.sliceToEnd(source, ~from = 1);
-  computeColumnAndLine(
-    tail,
-    pos - 1,
-    ~column = head === "\n" ? 1 : column + 1,
-    ~line = head === "\n" ? line + 1 : line
-  );
-};
+let rec computeColumnAndLine = (~column=1, ~line=1, ~pre="", source) =>
+  fun
+  | 0 => (column, line)
+  | pos => {
+      let head = Js.String.get(source, 0);
+      let tail = Js.String.sliceToEnd(source, ~from=1);
+      computeColumnAndLine(
+        tail,
+        pos - 1,
+        ~pre=head,
+        ~column=pre === "\n" ? 1 : column + 1,
+        ~line=pre === "\n" ? line + 1 : line
+      );
+    };
 
-let diagnosticOfTs = (sourceFile) => {
-  let { Typescript.text, parseDiagnostics } = sourceFile;
+let diagnosticOfTs = sourceFile => {
+  let {Typescript.text, parseDiagnostics} = sourceFile;
   parseDiagnostics
   |> Belt.List.ofArray
   |> List.map(d => {
-      let {Typescript.start, messageText } = d;
-      let (column, line) = computeColumnAndLine(text, start);
-      pp({
-        line,
-        column,
-        source: text,
-        reason: messageText,
-      })
-    })
+       let {Typescript.start, messageText} = d;
+       let (column, line) = computeColumnAndLine(text, start);
+       pp({line, column: column - 1, source: text, reason: messageText});
+     })
   |> String.concat("\n")
-  |> x => DiagnosticError(x)
+  |> (x => Error(x));
 };

--- a/src/diagnostic.re
+++ b/src/diagnostic.re
@@ -1,0 +1,64 @@
+exception DiagnosticError(string);
+
+type diagnostic = {
+  source: string,
+  line: int,
+  column: int,
+  reason: string
+};
+
+let pp = ({line, column, reason, source}) => {
+  let offset = Belt.List.make(column, " ") |> String.concat("");
+  source
+    |> Js.String.split("\n")
+    |> Belt.List.ofArray
+    |> Belt.List.getExn(_, (line - 1))
+    |> (s => Printf.sprintf("%s\n%s^ %s", s, offset, reason))
+};
+
+let diagnosticOfFlow = (errors, source) => {
+  errors
+    |> List.map(
+      ((loc, ty)) => {
+      let { Loc.line, column } = Loc.(loc.start);
+      pp({
+        line,
+        column,
+        source,
+        reason: Parse_error.PP.error(ty),
+      })
+    })
+    |> String.concat("\n")
+  |> x => DiagnosticError(x)
+};
+
+let rec computeColumnAndLine = (~column = 1, ~line = 1, source) => fun
+| 0 => (column, line)
+| pos => {
+  let head = Js.String.get(source, 0);
+  let tail = Js.String.sliceToEnd(source, ~from = 1);
+  computeColumnAndLine(
+    tail,
+    pos - 1,
+    ~column = head === "\n" ? 1 : column + 1,
+    ~line = head === "\n" ? line + 1 : line
+  );
+};
+
+let diagnosticOfTs = (sourceFile) => {
+  let { Typescript.text, parseDiagnostics } = sourceFile;
+  parseDiagnostics
+  |> Belt.List.ofArray
+  |> List.map(d => {
+      let {Typescript.start, messageText } = d;
+      let (column, line) = computeColumnAndLine(text, start);
+      pp({
+        line,
+        column,
+        source: text,
+        reason: messageText,
+      })
+    })
+  |> String.concat("\n")
+  |> x => DiagnosticError(x)
+};

--- a/src/diagnostic.re
+++ b/src/diagnostic.re
@@ -38,8 +38,7 @@ let diagnosticOfFlow = (errors, source) =>
          (),
        );
      })
-  |> String.concat("\n----------------\n")
-  |> (x => Error(x));
+  |> String.concat("\n----------------\n");
 
 let rec computeColumnAndLine = (~column=1, ~line=1, ~pre="", source) =>
   fun

--- a/src/typescriptBsType.re
+++ b/src/typescriptBsType.re
@@ -38,12 +38,16 @@ and typescriptAstToBsType =
 let rec typescriptAstToBsTypeAst =
   fun
   | Typescript.SourceFile(sourceFile) =>
-    BsTypeAst.ModuleDecl(
-      "\"" ++ Genutils.normalize_name(sourceFile.fileName) ++ "\"",
-      sourceFile.statements
-      |> Array.to_list
-      |> List.map(typescriptAstToBsTypeAst)
-    )
+    if (Array.length(sourceFile.parseDiagnostics) > 0) {
+      raise(Diagnostic.diagnosticOfTs(sourceFile));
+    } else {
+      BsTypeAst.ModuleDecl(
+        "\"" ++ Genutils.normalize_name(sourceFile.fileName) ++ "\"",
+        sourceFile.statements
+        |> Array.to_list
+        |> List.map(typescriptAstToBsTypeAst)
+      );
+    }
   | Typescript.FunctionDeclaration(func) =>
     BsTypeAst.FuncDecl(
       getName(func.name),


### PR DESCRIPTION
<!-- Please provide a brief description of the changes -->

Implement pretty-printer of parser-error   

<!-- If possible, provide sample input and output -->

### Input

Type definition which includes invalid syntax

```
declare v _;
```

### Output

<img src="https://user-images.githubusercontent.com/4057326/37207283-a1782312-23df-11e8-9d2b-70aa29cf29c6.png" width="500px"/>

### PR Checklist
- [x] Corresponding issue: #43 
- [x] Formatted code with `refmt`
- [x] Ran tests `npm test` and updated snapshots
